### PR TITLE
Remove the pdf.js duplication

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -5,40 +5,38 @@
 
     <engines>
         <engine name="cordova" version=">=3.4.0"/>
-        </engines>
+    </engines>
 
-        <asset src="www/pdf.js" target="js/pdf.js"/>
+    <js-module src="www/pdf.js" name="pdf">
+        <clobbers target="pdf"/>
+    </js-module>
 
-        <js-module src="www/pdf.js" name="pdf">
-            <clobbers target="pdf"/>
-        </js-module>
+    <platform name="android">
 
-        <platform name="android">
+        <config-file target="res/xml/config.xml" parent="/*">
+            <feature name="PDFService">
+                <param name="android-package" value="com.pdf.generator.PDFGenerator"/>
+            </feature>
+        </config-file>
 
-              <config-file target="res/xml/config.xml" parent="/*">
-                <feature name="PDFService">
-                    <param name="android-package" value="com.pdf.generator.PDFGenerator"/>
-                </feature>
-            </config-file>
+        <source-file src="src/android/PDFGenerator.java" target-dir="src/com/pdf/generator/"/>
+        <source-file src="src/android/PDFPrinter.java" target-dir="src/com/pdf/generator/"/>
+        <source-file src="src/android/PDFPrinterWebView.java" target-dir="src/com/pdf/generator/"/>
 
-            <source-file src="src/android/PDFGenerator.java" target-dir="src/com/pdf/generator/"/>
-            <source-file src="src/android/PDFPrinter.java" target-dir="src/com/pdf/generator/"/>
-            <source-file src="src/android/PDFPrinterWebView.java" target-dir="src/com/pdf/generator/"/>
+    </platform>
 
-        </platform>
+    <platform name="ios">
 
-        <platform name="ios">
+        <config-file target="config.xml" parent="/widget">
+            <feature name="pdfService">
+                <param name="ios-package" value="PDFGenerator"/>
+            </feature>
+        </config-file>
 
-            <config-file target="config.xml" parent="/widget">
-                <feature name="pdfService">
-                    <param name="ios-package" value="PDFGenerator"/>
-                </feature>
-            </config-file>
+        <header-file src="src/ios/BNHtmlPdfKit.h"/>
+        <header-file src="src/ios/PDFGenerator.h"/>
+        <source-file src="src/ios/PDFGenerator.m"/>
+        <source-file src="src/ios/BNHtmlPdfKit.m"/>
 
-            <header-file src="src/ios/BNHtmlPdfKit.h"/>
-            <header-file src="src/ios/PDFGenerator.h"/>
-            <source-file src="src/ios/PDFGenerator.m"/>
-            <source-file src="src/ios/BNHtmlPdfKit.m"/>
-        </platform>
-
-    </plugin>
+    </platform>
+</plugin>


### PR DESCRIPTION
Removed the asset tag for pdf.js as it's not needed and duplicates the file. Cordova already handles it with the js-module tag.

Also formatted the plugin.xml file.